### PR TITLE
add route commands to protobuf definition

### DIFF
--- a/PythonClient/carla/carla_server_pb2.py
+++ b/PythonClient/carla/carla_server_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='carla_server.proto',
   package='carla_server',
   syntax='proto3',
-  serialized_pb=_b('\n\x12\x63\x61rla_server.proto\x12\x0c\x63\x61rla_server\"+\n\x08Vector3D\x12\t\n\x01x\x18\x01 \x01(\x02\x12\t\n\x01y\x18\x02 \x01(\x02\x12\t\n\x01z\x18\x03 \x01(\x02\"6\n\nRotation3D\x12\r\n\x05pitch\x18\x01 \x01(\x02\x12\x0b\n\x03yaw\x18\x02 \x01(\x02\x12\x0c\n\x04roll\x18\x03 \x01(\x02\"\x92\x01\n\tTransform\x12(\n\x08location\x18\x01 \x01(\x0b\x32\x16.carla_server.Vector3D\x12/\n\x0borientation\x18\x02 \x01(\x0b\x32\x16.carla_server.Vector3DB\x02\x18\x01\x12*\n\x08rotation\x18\x03 \x01(\x0b\x32\x18.carla_server.Rotation3D\"x\n\x07Vehicle\x12*\n\ttransform\x18\x01 \x01(\x0b\x32\x17.carla_server.Transform\x12*\n\nbox_extent\x18\x02 \x01(\x0b\x32\x16.carla_server.Vector3D\x12\x15\n\rforward_speed\x18\x03 \x01(\x02\"{\n\nPedestrian\x12*\n\ttransform\x18\x01 \x01(\x0b\x32\x17.carla_server.Transform\x12*\n\nbox_extent\x18\x02 \x01(\x0b\x32\x16.carla_server.Vector3D\x12\x15\n\rforward_speed\x18\x03 \x01(\x02\"\x94\x01\n\x0cTrafficLight\x12*\n\ttransform\x18\x01 \x01(\x0b\x32\x17.carla_server.Transform\x12/\n\x05state\x18\x02 \x01(\x0e\x32 .carla_server.TrafficLight.State\"\'\n\x05State\x12\t\n\x05GREEN\x10\x00\x12\n\n\x06YELLOW\x10\x01\x12\x07\n\x03RED\x10\x02\"Q\n\x0eSpeedLimitSign\x12*\n\ttransform\x18\x01 \x01(\x0b\x32\x17.carla_server.Transform\x12\x13\n\x0bspeed_limit\x18\x02 \x01(\x02\"\xe5\x01\n\x05\x41gent\x12\n\n\x02id\x18\x01 \x01(\x07\x12(\n\x07vehicle\x18\x02 \x01(\x0b\x32\x15.carla_server.VehicleH\x00\x12.\n\npedestrian\x18\x03 \x01(\x0b\x32\x18.carla_server.PedestrianH\x00\x12\x33\n\rtraffic_light\x18\x04 \x01(\x0b\x32\x1a.carla_server.TrafficLightH\x00\x12\x38\n\x10speed_limit_sign\x18\x05 \x01(\x0b\x32\x1c.carla_server.SpeedLimitSignH\x00\x42\x07\n\x05\x61gent\"%\n\x11RequestNewEpisode\x12\x10\n\x08ini_file\x18\x01 \x01(\t\"G\n\x10SceneDescription\x12\x33\n\x12player_start_spots\x18\x01 \x03(\x0b\x32\x17.carla_server.Transform\"/\n\x0c\x45pisodeStart\x12\x1f\n\x17player_start_spot_index\x18\x01 \x01(\r\"\x1d\n\x0c\x45pisodeReady\x12\r\n\x05ready\x18\x01 \x01(\x08\"^\n\x07\x43ontrol\x12\r\n\x05steer\x18\x01 \x01(\x02\x12\x10\n\x08throttle\x18\x02 \x01(\x02\x12\r\n\x05\x62rake\x18\x03 \x01(\x02\x12\x12\n\nhand_brake\x18\x04 \x01(\x08\x12\x0f\n\x07reverse\x18\x05 \x01(\x08\"\x8a\x04\n\x0cMeasurements\x12\x1a\n\x12platform_timestamp\x18\x01 \x01(\r\x12\x16\n\x0egame_timestamp\x18\x02 \x01(\r\x12J\n\x13player_measurements\x18\x03 \x01(\x0b\x32-.carla_server.Measurements.PlayerMeasurements\x12.\n\x11non_player_agents\x18\x04 \x03(\x0b\x32\x13.carla_server.Agent\x1a\xc9\x02\n\x12PlayerMeasurements\x12*\n\ttransform\x18\x01 \x01(\x0b\x32\x17.carla_server.Transform\x12,\n\x0c\x61\x63\x63\x65leration\x18\x03 \x01(\x0b\x32\x16.carla_server.Vector3D\x12\x15\n\rforward_speed\x18\x04 \x01(\x02\x12\x1a\n\x12\x63ollision_vehicles\x18\x05 \x01(\x02\x12\x1d\n\x15\x63ollision_pedestrians\x18\x06 \x01(\x02\x12\x17\n\x0f\x63ollision_other\x18\x07 \x01(\x02\x12\x1e\n\x16intersection_otherlane\x18\x08 \x01(\x02\x12\x1c\n\x14intersection_offroad\x18\t \x01(\x02\x12\x30\n\x11\x61utopilot_control\x18\n \x01(\x0b\x32\x15.carla_server.ControlB\x03\xf8\x01\x01\x62\x06proto3')
+  serialized_pb=_b('\n\x12\x63\x61rla_server.proto\x12\x0c\x63\x61rla_server\"+\n\x08Vector3D\x12\t\n\x01x\x18\x01 \x01(\x02\x12\t\n\x01y\x18\x02 \x01(\x02\x12\t\n\x01z\x18\x03 \x01(\x02\"6\n\nRotation3D\x12\r\n\x05pitch\x18\x01 \x01(\x02\x12\x0b\n\x03yaw\x18\x02 \x01(\x02\x12\x0c\n\x04roll\x18\x03 \x01(\x02\"\x92\x01\n\tTransform\x12(\n\x08location\x18\x01 \x01(\x0b\x32\x16.carla_server.Vector3D\x12/\n\x0borientation\x18\x02 \x01(\x0b\x32\x16.carla_server.Vector3DB\x02\x18\x01\x12*\n\x08rotation\x18\x03 \x01(\x0b\x32\x18.carla_server.Rotation3D\"x\n\x07Vehicle\x12*\n\ttransform\x18\x01 \x01(\x0b\x32\x17.carla_server.Transform\x12*\n\nbox_extent\x18\x02 \x01(\x0b\x32\x16.carla_server.Vector3D\x12\x15\n\rforward_speed\x18\x03 \x01(\x02\"{\n\nPedestrian\x12*\n\ttransform\x18\x01 \x01(\x0b\x32\x17.carla_server.Transform\x12*\n\nbox_extent\x18\x02 \x01(\x0b\x32\x16.carla_server.Vector3D\x12\x15\n\rforward_speed\x18\x03 \x01(\x02\"\x94\x01\n\x0cTrafficLight\x12*\n\ttransform\x18\x01 \x01(\x0b\x32\x17.carla_server.Transform\x12/\n\x05state\x18\x02 \x01(\x0e\x32 .carla_server.TrafficLight.State\"\'\n\x05State\x12\t\n\x05GREEN\x10\x00\x12\n\n\x06YELLOW\x10\x01\x12\x07\n\x03RED\x10\x02\"Q\n\x0eSpeedLimitSign\x12*\n\ttransform\x18\x01 \x01(\x0b\x32\x17.carla_server.Transform\x12\x13\n\x0bspeed_limit\x18\x02 \x01(\x02\"\xe5\x01\n\x05\x41gent\x12\n\n\x02id\x18\x01 \x01(\x07\x12(\n\x07vehicle\x18\x02 \x01(\x0b\x32\x15.carla_server.VehicleH\x00\x12.\n\npedestrian\x18\x03 \x01(\x0b\x32\x18.carla_server.PedestrianH\x00\x12\x33\n\rtraffic_light\x18\x04 \x01(\x0b\x32\x1a.carla_server.TrafficLightH\x00\x12\x38\n\x10speed_limit_sign\x18\x05 \x01(\x0b\x32\x1c.carla_server.SpeedLimitSignH\x00\x42\x07\n\x05\x61gent\"%\n\x11RequestNewEpisode\x12\x10\n\x08ini_file\x18\x01 \x01(\t\"G\n\x10SceneDescription\x12\x33\n\x12player_start_spots\x18\x01 \x03(\x0b\x32\x17.carla_server.Transform\"/\n\x0c\x45pisodeStart\x12\x1f\n\x17player_start_spot_index\x18\x01 \x01(\r\"\x1d\n\x0c\x45pisodeReady\x12\r\n\x05ready\x18\x01 \x01(\x08\"\x8a\x02\n\x07\x43ontrol\x12\r\n\x05steer\x18\x01 \x01(\x02\x12\x10\n\x08throttle\x18\x02 \x01(\x02\x12\r\n\x05\x62rake\x18\x03 \x01(\x02\x12\x12\n\nhand_brake\x18\x04 \x01(\x08\x12\x0f\n\x07reverse\x18\x05 \x01(\x08\x12\x39\n\rroute_command\x18\x06 \x01(\x0e\x32\".carla_server.Control.RouteCommand\"o\n\x0cRouteCommand\x12\x10\n\x0cGOAL_REACHED\x10\x00\x12\x0c\n\x08UNUSED_1\x10\x01\x12\x0f\n\x0bLANE_FOLLOW\x10\x02\x12\r\n\tTURN_LEFT\x10\x03\x12\x0e\n\nTURN_RIGHT\x10\x04\x12\x0f\n\x0bGO_STRAIGHT\x10\x05\"\x8a\x04\n\x0cMeasurements\x12\x1a\n\x12platform_timestamp\x18\x01 \x01(\r\x12\x16\n\x0egame_timestamp\x18\x02 \x01(\r\x12J\n\x13player_measurements\x18\x03 \x01(\x0b\x32-.carla_server.Measurements.PlayerMeasurements\x12.\n\x11non_player_agents\x18\x04 \x03(\x0b\x32\x13.carla_server.Agent\x1a\xc9\x02\n\x12PlayerMeasurements\x12*\n\ttransform\x18\x01 \x01(\x0b\x32\x17.carla_server.Transform\x12,\n\x0c\x61\x63\x63\x65leration\x18\x03 \x01(\x0b\x32\x16.carla_server.Vector3D\x12\x15\n\rforward_speed\x18\x04 \x01(\x02\x12\x1a\n\x12\x63ollision_vehicles\x18\x05 \x01(\x02\x12\x1d\n\x15\x63ollision_pedestrians\x18\x06 \x01(\x02\x12\x17\n\x0f\x63ollision_other\x18\x07 \x01(\x02\x12\x1e\n\x16intersection_otherlane\x18\x08 \x01(\x02\x12\x1c\n\x14intersection_offroad\x18\t \x01(\x02\x12\x30\n\x11\x61utopilot_control\x18\n \x01(\x0b\x32\x15.carla_server.ControlB\x03\xf8\x01\x01\x62\x06proto3')
 )
 
 
@@ -49,6 +49,44 @@ _TRAFFICLIGHT_STATE = _descriptor.EnumDescriptor(
   serialized_end=682,
 )
 _sym_db.RegisterEnumDescriptor(_TRAFFICLIGHT_STATE)
+
+_CONTROL_ROUTECOMMAND = _descriptor.EnumDescriptor(
+  name='RouteCommand',
+  full_name='carla_server.Control.RouteCommand',
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='GOAL_REACHED', index=0, number=0,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='UNUSED_1', index=1, number=1,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='LANE_FOLLOW', index=2, number=2,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='TURN_LEFT', index=3, number=3,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='TURN_RIGHT', index=4, number=4,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='GO_STRAIGHT', index=5, number=5,
+      options=None,
+      type=None),
+  ],
+  containing_type=None,
+  options=None,
+  serialized_start=1347,
+  serialized_end=1458,
+)
+_sym_db.RegisterEnumDescriptor(_CONTROL_ROUTECOMMAND)
 
 
 _VECTOR3D = _descriptor.Descriptor(
@@ -581,11 +619,19 @@ _CONTROL = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
+    _descriptor.FieldDescriptor(
+      name='route_command', full_name='carla_server.Control.route_command', index=5,
+      number=6, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
   ],
   extensions=[
   ],
   nested_types=[],
   enum_types=[
+    _CONTROL_ROUTECOMMAND,
   ],
   options=None,
   is_extendable=False,
@@ -593,8 +639,8 @@ _CONTROL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1191,
-  serialized_end=1285,
+  serialized_start=1192,
+  serialized_end=1458,
 )
 
 
@@ -680,8 +726,8 @@ _MEASUREMENTS_PLAYERMEASUREMENTS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1481,
-  serialized_end=1810,
+  serialized_start=1654,
+  serialized_end=1983,
 )
 
 _MEASUREMENTS = _descriptor.Descriptor(
@@ -731,8 +777,8 @@ _MEASUREMENTS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1288,
-  serialized_end=1810,
+  serialized_start=1461,
+  serialized_end=1983,
 )
 
 _TRANSFORM.fields_by_name['location'].message_type = _VECTOR3D
@@ -763,6 +809,8 @@ _AGENT.oneofs_by_name['agent'].fields.append(
   _AGENT.fields_by_name['speed_limit_sign'])
 _AGENT.fields_by_name['speed_limit_sign'].containing_oneof = _AGENT.oneofs_by_name['agent']
 _SCENEDESCRIPTION.fields_by_name['player_start_spots'].message_type = _TRANSFORM
+_CONTROL.fields_by_name['route_command'].enum_type = _CONTROL_ROUTECOMMAND
+_CONTROL_ROUTECOMMAND.containing_type = _CONTROL
 _MEASUREMENTS_PLAYERMEASUREMENTS.fields_by_name['transform'].message_type = _TRANSFORM
 _MEASUREMENTS_PLAYERMEASUREMENTS.fields_by_name['acceleration'].message_type = _VECTOR3D
 _MEASUREMENTS_PLAYERMEASUREMENTS.fields_by_name['autopilot_control'].message_type = _CONTROL

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/AI/RouteCommand.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/AI/RouteCommand.h
@@ -1,0 +1,14 @@
+
+#pragma once
+
+#include "RouteCommand.generated.h"
+
+UENUM(BlueprintType)
+enum class ERouteCommand : uint8 {
+  GoalReached  UMETA(DisplayName = "GoalReached"),
+  Unused_1     UMETA(DisplayName = "Unused_1"),
+  LaneFollow   UMETA(DisplayName = "LaneFollow"),
+  TurnLeft     UMETA(DisplayName = "TurnLeft"),
+  TurnRight    UMETA(DisplayName = "TurnRight"),
+  GoStraight   UMETA(DisplayName = "GoStraight")
+};

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/AI/WheeledVehicleAIController.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/AI/WheeledVehicleAIController.h
@@ -10,6 +10,7 @@
 
 #include "GameFramework/PlayerController.h"
 #include "TrafficLightState.h"
+#include "RouteCommand.h"
 #include "WheeledVehicleAIController.generated.h"
 
 class ACarlaWheeledVehicle;
@@ -175,6 +176,13 @@ public:
   UFUNCTION(Category = "Wheeled Vehicle Controller", BlueprintCallable)
   void SetFixedRoute(const TArray<FVector> &Locations, bool bOverwriteCurrent=true);
 
+  /// Get the route command based on the FixedRoute (if set by autopilot)
+  UFUNCTION(Category = "Wheeled Vehicle Controller", BlueprintCallable)
+  ERouteCommand GetRouteCommand() const
+  {
+    return RouteCommand;
+  }
+
   /// @}
   // ===========================================================================
   /// @name AI
@@ -237,7 +245,10 @@ private:
   UPROPERTY(VisibleAnywhere)
   float MaximumSteerAngle = -1.0f;
 
-  FAutopilotControl AutopilotControl;
+  UPROPERTY(VisibleAnywhere)
+  ERouteCommand RouteCommand = ERouteCommand::LaneFollow;
+  double TimeRouteCommandSet = 5.f;
 
+  FAutopilotControl AutopilotControl;
   std::queue<FVector> TargetLocations;
 };

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/CityMapGenerator.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/CityMapGenerator.cpp
@@ -6,6 +6,7 @@
 
 #include "Carla.h"
 #include "CityMapGenerator.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 #include "MapGen/GraphGenerator.h"
 #include "MapGen/RoadMap.h"
@@ -291,7 +292,11 @@ void ACityMapGenerator::GenerateRoadMap()
 #endif // WITH_EDITOR
 
   if (bSaveRoadMapToDisk) {
+#if ENGINE_MINOR_VERSION >= 18
+    RoadMap->SaveAsPNG(FPaths::ProjectSavedDir(), World->GetMapName());
+#else
     RoadMap->SaveAsPNG(FPaths::GameSavedDir(), World->GetMapName());
+#endif
   }
 
 #if WITH_EDITOR

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/DynamicWeather.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/DynamicWeather.cpp
@@ -10,6 +10,7 @@
 #include "Util/IniFile.h"
 
 #include "Components/ArrowComponent.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 static FString GetIniFileName(const FString &MapName = TEXT(""))
 {
@@ -21,7 +22,11 @@ static FString GetIniFileName(const FString &MapName = TEXT(""))
 
 static bool GetWeatherIniFilePath(const FString &FileName, FString &FilePath)
 {
+#if ENGINE_MINOR_VERSION >= 18
+  FilePath = FPaths::Combine(FPaths::ProjectConfigDir(), FileName);
+#else
   FilePath = FPaths::Combine(FPaths::GameConfigDir(), FileName);
+#endif
   const bool bFileExists = FPaths::FileExists(FilePath);
   if (!bFileExists) {
     UE_LOG(LogCarla, Warning, TEXT("\"%s\" not found"), *FilePath);

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaHUD.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaHUD.cpp
@@ -61,6 +61,20 @@ static FText GetTrafficLightAsText(ETrafficLightState State)
   }
 }
 
+
+static FText GetRouteCommandAsText(ERouteCommand State)
+{
+  switch (State) {
+    case ERouteCommand::GoalReached: return FText(LOCTEXT("GoalReachedCommand",   "GoalReached"));
+    case ERouteCommand::Unused_1:    return FText(LOCTEXT("Unused_1Command",   "Unused_1"));
+    case ERouteCommand::LaneFollow:  return FText(LOCTEXT("LaneFollowCommand",   "LaneFollow"));
+    case ERouteCommand::TurnRight:   return FText(LOCTEXT("TurnRightCommand",    "TurnRight"));
+    case ERouteCommand::TurnLeft:    return FText(LOCTEXT("TurnLeftCommand",     "TurnLeft"));
+    case ERouteCommand::GoStraight:  return FText(LOCTEXT("GoStraightCommand",   "GoStraight"));
+    default:                         return FText(LOCTEXT("InvalidRouteCommand", "INVALID"));
+  }
+}
+
 static FText GetHUDText(const ACarlaPlayerState &Vehicle)
 {
   // Set number precision.
@@ -77,6 +91,7 @@ static FText GetHUDText(const ACarlaPlayerState &Vehicle)
   Args.Add("Gear", GetGearAsText(Vehicle.GetCurrentGear()));
   Args.Add("SpeedLimit", RoundedFloatAsText(Vehicle.GetSpeedLimit()));
   Args.Add("TrafficLightState", GetTrafficLightAsText(Vehicle.GetTrafficLightState()));
+  Args.Add("RouteCommand", GetRouteCommandAsText(Vehicle.GetRouteCommand()));
   Args.Add("CollisionCars", RoundedFloatAsText(Vehicle.GetCollisionIntensityCars()));
   Args.Add("CollisionPedestrians", RoundedFloatAsText(Vehicle.GetCollisionIntensityPedestrians()));
   Args.Add("CollisionOther", RoundedFloatAsText(Vehicle.GetCollisionIntensityOther()));
@@ -91,6 +106,7 @@ static FText GetHUDText(const ACarlaPlayerState &Vehicle)
           "\n"
           "Speed Limit:   {SpeedLimit} km/h\n"
           "Traffic Light: {TrafficLightState}\n"
+          "Route Command: {RouteCommand}\n"
           "\n"
           "Location:      {Location}\n"
           "Orientation:   {Orientation}\n"

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaPlayerState.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaPlayerState.cpp
@@ -39,6 +39,7 @@ void ACarlaPlayerState::CopyProperties(APlayerState *PlayerState)
       CurrentGear = Other->CurrentGear;
       SpeedLimit = Other->SpeedLimit;
       TrafficLightState = Other->TrafficLightState;
+      RouteCommand = Other->RouteCommand;
       CollisionIntensityCars = Other->CollisionIntensityCars;
       CollisionIntensityPedestrians = Other->CollisionIntensityPedestrians;
       CollisionIntensityOther = Other->CollisionIntensityOther;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaPlayerState.h
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaPlayerState.h
@@ -8,6 +8,7 @@
 
 #include "GameFramework/PlayerState.h"
 #include "AI/TrafficLightState.h"
+#include "AI/RouteCommand.h"
 #include "CapturedImage.h"
 #include "CarlaPlayerState.generated.h"
 
@@ -141,6 +142,12 @@ public:
     return TrafficLightState;
   }
 
+  UFUNCTION(BlueprintCallable)
+  ERouteCommand GetRouteCommand() const
+  {
+    return RouteCommand;
+  }
+
   /// @}
   // ===========================================================================
   /// @name Collision
@@ -268,6 +275,9 @@ private:
 
   UPROPERTY(VisibleAnywhere)
   ETrafficLightState TrafficLightState = ETrafficLightState::Green;
+
+  UPROPERTY(VisibleAnywhere)
+  ERouteCommand RouteCommand = ERouteCommand::LaneFollow;
 
   UPROPERTY(VisibleAnywhere)
   float CollisionIntensityCars = 0.0f;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaServer.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaServer.cpp
@@ -89,6 +89,11 @@ static void Set(carla_image &cImage, const FCapturedImage &uImage)
   }
 }
 
+static inline void Set(uint8_t &lhs, const ERouteCommand &rhs)
+{
+  lhs = static_cast<uint8_t>(rhs);
+}
+
 static void SetBoxSpeedAndType(carla_agent &values, const ACharacter *Walker)
 {
   values.type = CARLA_SERVER_AGENT_PEDESTRIAN;
@@ -324,6 +329,7 @@ CarlaServer::ErrorCode CarlaServer::SendMeasurements(
   Set(player.autopilot_control.brake, PlayerState.GetBrake());
   Set(player.autopilot_control.hand_brake, PlayerState.GetHandBrake());
   Set(player.autopilot_control.reverse, PlayerState.GetCurrentGear() < 0);
+  Set(player.autopilot_control.route_command, PlayerState.GetRouteCommand());
 
   TArray<carla_agent> Agents;
   if (bSendNonPlayerAgentsInfo) {

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaVehicleController.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Game/CarlaVehicleController.cpp
@@ -90,6 +90,7 @@ void ACarlaVehicleController::Tick(float DeltaTime)
     CarlaPlayerState->Acceleration = (CurrentSpeed - PreviousSpeed) / DeltaTime;
     const auto &AutopilotControl = GetAutopilotControl();
     CarlaPlayerState->Steer = AutopilotControl.Steer;
+    CarlaPlayerState->RouteCommand = GetRouteCommand();
     CarlaPlayerState->Throttle = AutopilotControl.Throttle;
     CarlaPlayerState->Brake = AutopilotControl.Brake;
     CarlaPlayerState->bHandBrake = AutopilotControl.bHandBrake;

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/SceneCaptureToDiskCamera.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/SceneCaptureToDiskCamera.cpp
@@ -9,10 +9,15 @@
 
 #include "HighResScreenshot.h"
 #include "Paths.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 ASceneCaptureToDiskCamera::ASceneCaptureToDiskCamera(const FObjectInitializer& ObjectInitializer) :
   Super(ObjectInitializer),
+#if ENGINE_MINOR_VERSION >= 18
+  SaveToFolder(FPaths::Combine(FPaths::ProjectSavedDir(), "SceneCaptures")),
+#else
   SaveToFolder(FPaths::Combine(FPaths::GameSavedDir(), "SceneCaptures")),
+#endif
   FileName("capture_%05d.png") {}
 
 void ASceneCaptureToDiskCamera::BeginPlay()

--- a/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettings.cpp
+++ b/Unreal/CarlaUE4/Plugins/Carla/Source/Carla/Settings/CarlaSettings.cpp
@@ -145,7 +145,11 @@ void UCarlaSettings::LoadSettings()
 {
   CurrentFileName = TEXT("");
   // Load settings from project Config folder if present.
+#if ENGINE_MINOR_VERSION >= 18
+  LoadSettingsFromFile(FPaths::Combine(FPaths::ProjectConfigDir(), TEXT("CarlaSettings.ini")), false);
+#else
   LoadSettingsFromFile(FPaths::Combine(FPaths::GameConfigDir(), TEXT("CarlaSettings.ini")), false);
+#endif
   // Load settings given by command-line arg if provided.
   {
     FString FilePath;

--- a/Util/CarlaServer/include/carla/carla_server.h
+++ b/Util/CarlaServer/include/carla/carla_server.h
@@ -122,6 +122,7 @@ extern "C" {
     float brake;
     bool hand_brake;
     bool reverse;
+    uint8_t route_command;
   };
 
   /* ======================================================================== */

--- a/Util/CarlaServer/source/carla/server/CarlaEncoder.cpp
+++ b/Util/CarlaServer/source/carla/server/CarlaEncoder.cpp
@@ -55,6 +55,8 @@ namespace server {
     lhs->set_brake(rhs.brake);
     lhs->set_hand_brake(rhs.hand_brake);
     lhs->set_reverse(rhs.reverse);
+    lhs->set_route_command(
+      static_cast< ::carla_server::Control_RouteCommand >(rhs.route_command));
   }
 
   static void SetVehicle(cs::Vehicle *lhs, const carla_agent &rhs) {

--- a/Util/Proto/carla_server.proto
+++ b/Util/Proto/carla_server.proto
@@ -94,11 +94,20 @@ message EpisodeReady {
 // =============================================================================
 
 message Control {
+  enum RouteCommand {
+    GOAL_REACHED = 0;
+    UNUSED_1 = 1;
+    LANE_FOLLOW = 2;
+    TURN_LEFT = 3;
+    TURN_RIGHT = 4;
+    GO_STRAIGHT = 5;
+  }
   float steer = 1;
   float throttle = 2;
   float brake = 3;
   bool hand_brake = 4;
   bool reverse = 5;
+  RouteCommand route_command = 6;
 }
 
 message Measurements {


### PR DESCRIPTION
Add route commands to CARLA protobuf definition
Update autopilot to set the route command when it enters a RoutePlanner node
Fix some deprecated calls for UnrealEngine 4.18
